### PR TITLE
Add Multi Url Picker Udi support

### DIFF
--- a/Source/Our.Umbraco.Nexu.Parsers.Tests/PropertyParsers/Community/RjpMultiUrlPickerParserTests.cs
+++ b/Source/Our.Umbraco.Nexu.Parsers.Tests/PropertyParsers/Community/RjpMultiUrlPickerParserTests.cs
@@ -1,14 +1,18 @@
 ﻿namespace Our.Umbraco.Nexu.Parsers.Tests.PropertyParsers.Community
 {
+    using System;
     using System.Linq;
 
+    using global::Umbraco.Core.Cache;
     using global::Umbraco.Core.Models;
+    using global::Umbraco.Core.Services;
+
+    using Moq;
 
     using NUnit.Framework;
 
     using Our.Umbraco.Nexu.Core.Enums;
     using Our.Umbraco.Nexu.Parsers.PropertyParsers.Community;
-    using Our.Umbraco.Nexu.Parsers.PropertyParsers.Core;
 
     /// <summary>
     /// The rjp multi url picker parser tests.
@@ -119,6 +123,71 @@
                             ""icon"": ""icon-document""
                           }}
                         ]";
+
+            // act
+            var result = parser.GetLinkedEntities(propValue);
+
+            // verify
+            Assert.IsNotNull(result);
+            var entities = result.ToList();
+            Assert.AreEqual(2, entities.Count());
+
+            Assert.IsTrue(entities.Exists(x => x.LinkedEntityType == LinkedEntityType.Document && x.Id == contentId));
+            Assert.IsTrue(entities.Exists(x => x.LinkedEntityType == LinkedEntityType.Media && x.Id == mediaId));
+        }
+
+        /// <summary>
+        /// The test get linked entities with Udi value.
+        /// </summary>
+        [Test]
+        [Category("PropertyParsers")]
+        [Category("CommunityPropertyParsers")]
+        public void TestGetLinkedEntitiesWithUdiValues()
+        {
+            // arrange
+            var cacheProviderMock = new Mock<ICacheProvider>();
+            cacheProviderMock.Setup(x => x.GetCacheItem(It.IsAny<string>(), It.IsAny<Func<object>>()))
+                .Returns((string k, Func<object> action) => action());
+
+            var contentKey = "633927e3e97e4769a9a00e563d0867c8";
+            var mediaKey = "ee44da039a9546788fdfa76ae40d1581";
+
+            var contentGuid = Guid.Parse(contentKey);
+            var mediaGuid = Guid.Parse(mediaKey);
+
+            var contentId = 1072;
+            var mediaId = 1092;
+
+            string propValue = $@"[
+                          {{
+                            ""udi"": ""umb://document/{contentKey}"",
+                            ""name"": ""Extend"",
+                            ""url"": ""/extend/""
+                          }},
+                          {{
+                            ""udi"": ""umb://media/{mediaKey}"",
+                            ""name"": ""Doc-Type-Grid-Editor---Developers-Guide-v1.1.pdf"",
+                            ""url"": ""/media/1057/doc-type-grid-editor-developers-guide-v11.pdf""
+                          }},
+                          {{
+                            ""name"": ""http://www.google.com"",
+                            ""url"": ""http://www.google.com""
+                          }}
+                        ]";
+
+            var contentServiceMock = new Mock<IContentService>();
+            var mediaServiceMock = new Mock<IMediaService>();
+
+            var contentMock = new Mock<IContent>();
+            contentMock.SetupGet(x => x.Id).Returns(contentId);
+
+            var mediaMock = new Mock<IMedia>();
+            mediaMock.SetupGet(x => x.Id).Returns(mediaId);
+
+            contentServiceMock.Setup(x => x.GetById(contentGuid)).Returns(contentMock.Object);
+            mediaServiceMock.Setup(x => x.GetById(mediaGuid)).Returns(mediaMock.Object);
+
+            var parser = new RjpMultiUrlPickerParser(contentServiceMock.Object, mediaServiceMock.Object, cacheProviderMock.Object);
 
             // act
             var result = parser.GetLinkedEntities(propValue);


### PR DESCRIPTION
Just released a new version of the Multi Url Picker for Umbraco 7.6 which stores Udi's instead of id's.
