### PR TITLE
Prevent pre-value errors, handle new thread exceptions

### DIFF
--- a/Source/Our.Umbraco.Nexu.Core/BootStrapper.cs
+++ b/Source/Our.Umbraco.Nexu.Core/BootStrapper.cs
@@ -1,4 +1,6 @@
-﻿namespace Our.Umbraco.Nexu.Core
+﻿using Umbraco.Core.Logging;
+
+namespace Our.Umbraco.Nexu.Core
 {
     using System;
     using System.Collections.Generic;
@@ -114,7 +116,14 @@
 
         private void ParseContentInBackground(object info)
         {
-            NexuService.Current.ParseContent((IContent)info);
+            try
+            {
+                NexuService.Current.ParseContent((IContent)info);
+            }
+            catch (Exception e)
+            {
+                LogHelper.Error<BootStrapper>("An unhandled exception occurred while parsing content", e);
+            }
         }
     }
 }

--- a/Source/Our.Umbraco.Nexu.Parsers/PropertyParsers/Community/VortoParser.cs
+++ b/Source/Our.Umbraco.Nexu.Parsers/PropertyParsers/Community/VortoParser.cs
@@ -85,7 +85,7 @@
                 var vortoDataType = this.dataTypeService.GetDataTypeDefinitionById(new Guid(vortoDataTypeGuid));
 
                 var preValues =
-                    this.dataTypeService.GetPreValuesCollectionByDataTypeId(vortoDataType.Id).PreValuesAsDictionary;
+                    this.dataTypeService.GetPreValuesCollectionByDataTypeId(vortoDataType.Id).FormatAsDictionary();
 
                 var editorDataTypeGuid = JsonConvert.DeserializeObject<JObject>(preValues["dataType"].Value).Value<string>("guid");
 

--- a/Source/Our.Umbraco.Nexu.Parsers/PropertyParsers/Core/MultiNodeTreePicker2ContentParser.cs
+++ b/Source/Our.Umbraco.Nexu.Parsers/PropertyParsers/Core/MultiNodeTreePicker2ContentParser.cs
@@ -89,7 +89,7 @@
             }
 
             var prevalues =
-                this.dataTypeService.GetPreValuesCollectionByDataTypeId(dataTypeDefinition.Id).PreValuesAsDictionary;
+                this.dataTypeService.GetPreValuesCollectionByDataTypeId(dataTypeDefinition.Id).FormatAsDictionary();
 
             if (!prevalues.ContainsKey("startNode"))
             {

--- a/Source/Our.Umbraco.Nexu.Parsers/PropertyParsers/Core/MultiNodeTreePicker2MediaParser.cs
+++ b/Source/Our.Umbraco.Nexu.Parsers/PropertyParsers/Core/MultiNodeTreePicker2MediaParser.cs
@@ -89,7 +89,7 @@
             }
 
             var prevalues =
-                this.dataTypeService.GetPreValuesCollectionByDataTypeId(dataTypeDefinition.Id).PreValuesAsDictionary;
+                this.dataTypeService.GetPreValuesCollectionByDataTypeId(dataTypeDefinition.Id).FormatAsDictionary();
 
             if (!prevalues.ContainsKey("startNode"))
             {

--- a/Source/Our.Umbraco.Nexu.Parsers/PropertyParsers/Core/MultiNodeTreePickerContentParser.cs
+++ b/Source/Our.Umbraco.Nexu.Parsers/PropertyParsers/Core/MultiNodeTreePickerContentParser.cs
@@ -62,7 +62,7 @@
             }
 
             var prevalues =
-                this.dataTypeService.GetPreValuesCollectionByDataTypeId(dataTypeDefinition.Id).PreValuesAsDictionary;
+                this.dataTypeService.GetPreValuesCollectionByDataTypeId(dataTypeDefinition.Id).FormatAsDictionary();
 
             if (!prevalues.ContainsKey("startNode"))
             {

--- a/Source/Our.Umbraco.Nexu.Parsers/PropertyParsers/Core/MultiNodeTreePickerMediaParser.cs
+++ b/Source/Our.Umbraco.Nexu.Parsers/PropertyParsers/Core/MultiNodeTreePickerMediaParser.cs
@@ -62,7 +62,7 @@
             }
 
             var prevalues =
-                this.dataTypeService.GetPreValuesCollectionByDataTypeId(dataTypeDefinition.Id).PreValuesAsDictionary;
+                this.dataTypeService.GetPreValuesCollectionByDataTypeId(dataTypeDefinition.Id).FormatAsDictionary();
 
             if (!prevalues.ContainsKey("startNode"))
             {


### PR DESCRIPTION
When accessing pre-values that are stored as arrays, using the PreValuesAsDictionary property throws an error.  Using the FormatAsDictionary method will return the internal dictionary if they are already stored as a dictionary, but if they are stored as an array it will convert them to a dictionary.  I have changed all references to PreValuesAsDictionary to reference FormatAsDictionary instead.

When executing in a new background thread, an unhandled exception will cause an app-domain abort, recycling the app pool.  I have changed the two places where a new thread is created to surround the method with a try/catch block that logs the error then exits the thread gracefully.