### PR TITLE
Grid editors in Umbraco Backoffice sometimes break

### DIFF
--- a/Source/Our.Umbraco.Nexu.Parsers/ParserHelper.cs
+++ b/Source/Our.Umbraco.Nexu.Parsers/ParserHelper.cs
@@ -6,6 +6,7 @@
     using System.Linq;
     using System.Text.RegularExpressions;
     using System.Web;
+    using System.Web.Hosting;
 
     using global::Umbraco.Core;
     using global::Umbraco.Core.Cache;
@@ -69,9 +70,14 @@
         /// </returns>
         public static string MapPath(string virtualPath)
         {
-            return HttpContext.Current == null
-                        ? Path.Combine(Directory.GetCurrentDirectory(), virtualPath)
-                        : HttpContext.Current.Server.MapPath(virtualPath);
+            if (HttpContext.Current == null)
+            {
+                return HostingEnvironment.IsHosted
+                    ? HostingEnvironment.MapPath(virtualPath)
+                    : Path.Combine(Directory.GetCurrentDirectory(), virtualPath);
+            }
+
+            return HttpContext.Current.Server.MapPath(virtualPath);
         }
 
         public static IEnumerable<ILinkedEntity> ParseRichText(string value)


### PR DESCRIPTION
Thanks for a great package! 🙏  

We are using Nexu on a couple of projects, but we have had the issue that Grid Editors sometimes break after a new release or when the app pool recycles.

This seems to be related to the way that Nexu is initializing because `HttpContext.Current` sometimes is `null` during the initialization phase. (Unfortunately we haven't been able to reproduce this issue consistently.)

However when `HttpContext.Current` is `null` it has the consequence that the grid config becomes empty as it maps to an non-existing grid config file. Because `UmbracoConfig` is a singleton this result is persisted and all grid editors fail to work in Umbraco Backoffice requiring the app pool to be recycled.

This it what it looks like in the backoffice when the grid config is empty:
![image](https://user-images.githubusercontent.com/359614/62624859-522aab00-b924-11e9-87e5-da01731b5d93.png)

This patch resolves the issue by using `HostingEnvironment.MapPath` when `HttpContext.Current` is `null`. In the existing code `Directory.GetCurrentDirectory()` returns `c:\windows\system32\inetsrv` when hosting the site in IIS.

I haven't gotten the unit tests to run as I get this error:
`Unable to find the requested .Net Framework Data Provider.  It may not be installed.`

Hopefully the unit tests still run 🤞 