### PR TITLE
Add support for Umbraco.MultiUrlPicker

### DIFF
--- a/Source/Our.Umbraco.Nexu.Core.Tests/Properties/AssemblyInfo.cs
+++ b/Source/Our.Umbraco.Nexu.Core.Tests/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.7.0.0")]
-[assembly: AssemblyFileVersion("1.7.0.0")]
+[assembly: AssemblyVersion("2.0.0.0")]
+[assembly: AssemblyFileVersion("2.0.0.0")]

--- a/Source/Our.Umbraco.Nexu.Core.Tests/Properties/AssemblyInfo.cs
+++ b/Source/Our.Umbraco.Nexu.Core.Tests/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.0.0")]
+[assembly: AssemblyVersion("1.7.1.0")]
+[assembly: AssemblyFileVersion("1.7.1.0")]

--- a/Source/Our.Umbraco.Nexu.Core/Properties/AssemblyInfo.cs
+++ b/Source/Our.Umbraco.Nexu.Core/Properties/AssemblyInfo.cs
@@ -34,7 +34,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.0.0")]
+[assembly: AssemblyVersion("1.7.1.0")]
+[assembly: AssemblyFileVersion("1.7.1.0")]
 
 

--- a/Source/Our.Umbraco.Nexu.Core/Properties/AssemblyInfo.cs
+++ b/Source/Our.Umbraco.Nexu.Core/Properties/AssemblyInfo.cs
@@ -34,7 +34,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.7.0.0")]
-[assembly: AssemblyFileVersion("1.7.0.0")]
+[assembly: AssemblyVersion("2.0.0.0")]
+[assembly: AssemblyFileVersion("2.0.0.0")]
 
 

--- a/Source/Our.Umbraco.Nexu.Parsers.Tests/Properties/AssemblyInfo.cs
+++ b/Source/Our.Umbraco.Nexu.Parsers.Tests/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.7.0.0")]
-[assembly: AssemblyFileVersion("1.7.0.0")]
+[assembly: AssemblyVersion("2.0.0.0")]
+[assembly: AssemblyFileVersion("2.0.0.0")]

--- a/Source/Our.Umbraco.Nexu.Parsers.Tests/Properties/AssemblyInfo.cs
+++ b/Source/Our.Umbraco.Nexu.Parsers.Tests/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.0.0")]
+[assembly: AssemblyVersion("1.7.1.0")]
+[assembly: AssemblyFileVersion("1.7.1.0")]

--- a/Source/Our.Umbraco.Nexu.Parsers.Tests/PropertyParsers/Community/RjpMultiUrlPickerParserTests.cs
+++ b/Source/Our.Umbraco.Nexu.Parsers.Tests/PropertyParsers/Community/RjpMultiUrlPickerParserTests.cs
@@ -41,6 +41,26 @@
         }
 
         /// <summary>
+        /// The test is parser for valid data type.
+        /// </summary>
+        [Test]
+        [Category("PropertyParsers")]
+        [Category("CommunityPropertyParsers")]
+        public void TestIsParserForNewDataType()
+        {
+            // arrange
+            var dataTypeDefinition = new DataTypeDefinition("Umbraco.MultiUrlPicker");
+
+            var parser = new RjpMultiUrlPickerParser();
+
+            // act
+            var result = parser.IsParserFor(dataTypeDefinition);
+
+            // verify
+            Assert.IsTrue(result);
+        }
+
+        /// <summary>
         /// The test is parser for in valid data type.
         /// </summary>
         [Test]

--- a/Source/Our.Umbraco.Nexu.Parsers/Properties/AssemblyInfo.cs
+++ b/Source/Our.Umbraco.Nexu.Parsers/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.7.0.0")]
-[assembly: AssemblyFileVersion("1.7.0.0")]
+[assembly: AssemblyVersion("2.0.0.0")]
+[assembly: AssemblyFileVersion("2.0.0.0")]

--- a/Source/Our.Umbraco.Nexu.Parsers/Properties/AssemblyInfo.cs
+++ b/Source/Our.Umbraco.Nexu.Parsers/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.0.0")]
+[assembly: AssemblyVersion("1.7.1.0")]
+[assembly: AssemblyFileVersion("1.7.1.0")]

--- a/Source/Our.Umbraco.Nexu.Parsers/PropertyParsers/Community/RjpMultiUrlPickerParser.cs
+++ b/Source/Our.Umbraco.Nexu.Parsers/PropertyParsers/Community/RjpMultiUrlPickerParser.cs
@@ -76,7 +76,7 @@
         /// </returns>
         public bool IsParserFor(IDataTypeDefinition dataTypeDefinition)
         {
-            return dataTypeDefinition.PropertyEditorAlias.Equals("RJP.MultiUrlPicker");
+            return dataTypeDefinition.PropertyEditorAlias.Equals("Umbraco.MultiUrlPicker") || dataTypeDefinition.PropertyEditorAlias.Equals("RJP.MultiUrlPicker");
         }
 
         /// <summary>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
 os: Visual Studio 2015
 
 # Version format
-version: 1.7.0.{build}
+version: 2.0.0.{build}
 
 cache:
   - Source\packages -> **\packages.config   # preserve "packages" directory in the root of build folder but will reset it if packages.config is modified
@@ -18,7 +18,7 @@ branches:
 # UMBRACO_PACKAGE_PRERELEASE_SUFFIX if a rtm release build this should be blank, otherwise if empty will default to alpha
 # example UMBRACO_PACKAGE_PRERELEASE_SUFFIX=beta
 init:
-  - set UMBRACO_PACKAGE_PRERELEASE_SUFFIX=rtm  
+  - set UMBRACO_PACKAGE_PRERELEASE_SUFFIX=beta  
 
 test: 
     assemblies:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
 os: Visual Studio 2015
 
 # Version format
-version: 2.0.0.{build}
+version: 1.7.1.{build}
 
 cache:
   - Source\packages -> **\packages.config   # preserve "packages" directory in the root of build folder but will reset it if packages.config is modified
@@ -18,7 +18,7 @@ branches:
 # UMBRACO_PACKAGE_PRERELEASE_SUFFIX if a rtm release build this should be blank, otherwise if empty will default to alpha
 # example UMBRACO_PACKAGE_PRERELEASE_SUFFIX=beta
 init:
-  - set UMBRACO_PACKAGE_PRERELEASE_SUFFIX=beta  
+  - set UMBRACO_PACKAGE_PRERELEASE_SUFFIX=rtm  
 
 test: 
     assemblies:


### PR DESCRIPTION
This pull request resolves issue #59 by adding support for the Umbraco.MultiUrlPicker data type in the RjpMultiUrlPickerParser control.  This allows users on Umbraco 7.14+ to still be able to get parsed results for the MultiUrlPicker control now bundled with Umbraco.