### PR TITLE
Use CompositionPropertyTypes

### DIFF
--- a/Source/Our.Umbraco.Nexu.Core.Tests/Properties/AssemblyInfo.cs
+++ b/Source/Our.Umbraco.Nexu.Core.Tests/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.7.3.0")]
-[assembly: AssemblyFileVersion("1.7.3.0")]
+[assembly: AssemblyVersion("1.7.4.0")]
+[assembly: AssemblyFileVersion("1.7.4.0")]

--- a/Source/Our.Umbraco.Nexu.Core/Properties/AssemblyInfo.cs
+++ b/Source/Our.Umbraco.Nexu.Core/Properties/AssemblyInfo.cs
@@ -34,7 +34,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.7.3.0")]
-[assembly: AssemblyFileVersion("1.7.3.0")]
+[assembly: AssemblyVersion("1.7.4.0")]
+[assembly: AssemblyFileVersion("1.7.4.0")]
 
 

--- a/Source/Our.Umbraco.Nexu.Parsers.Tests/GridEditorParsers/Community/DocTypeGridEditorParserTests.cs
+++ b/Source/Our.Umbraco.Nexu.Parsers.Tests/GridEditorParsers/Community/DocTypeGridEditorParserTests.cs
@@ -128,7 +128,7 @@
 
             var contentTypeMock = new Mock<IContentType>();
 
-            contentTypeMock.SetupGet(x => x.PropertyTypes)
+            contentTypeMock.SetupGet(x => x.CompositionPropertyTypes)
                 .Returns(
                     new List<PropertyType>
                         {

--- a/Source/Our.Umbraco.Nexu.Parsers.Tests/Properties/AssemblyInfo.cs
+++ b/Source/Our.Umbraco.Nexu.Parsers.Tests/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.7.3.0")]
-[assembly: AssemblyFileVersion("1.7.3.0")]
+[assembly: AssemblyVersion("1.7.4.0")]
+[assembly: AssemblyFileVersion("1.7.4.0")]

--- a/Source/Our.Umbraco.Nexu.Parsers.Tests/PropertyParsers/Community/ContentListParserTests.cs
+++ b/Source/Our.Umbraco.Nexu.Parsers.Tests/PropertyParsers/Community/ContentListParserTests.cs
@@ -134,7 +134,7 @@
             // setup content types and content service calls
             var contentType1 = new Mock<IContentType>();
 
-            contentType1.SetupGet(x => x.PropertyTypes)
+            contentType1.SetupGet(x => x.CompositionPropertyTypes)
                 .Returns(new List<PropertyType>
                              {
                                  new PropertyType(rteDataTypeDefinition, text),
@@ -143,7 +143,7 @@
 
             var contentType2 = new Mock<IContentType>();
 
-            contentType2.SetupGet(x => x.PropertyTypes)
+            contentType2.SetupGet(x => x.CompositionPropertyTypes)
                 .Returns(new List<PropertyType>
                              {
                                  new PropertyType(contentPickerDataTypeDefinition, link),

--- a/Source/Our.Umbraco.Nexu.Parsers.Tests/PropertyParsers/Community/NestedContentParserTests.cs
+++ b/Source/Our.Umbraco.Nexu.Parsers.Tests/PropertyParsers/Community/NestedContentParserTests.cs
@@ -105,12 +105,12 @@
 
             var ncContentPickerContentType = new Mock<IContentType>();           
 
-            ncContentPickerContentType.SetupGet(x => x.PropertyTypes)
+            ncContentPickerContentType.SetupGet(x => x.CompositionPropertyTypes)
                 .Returns(new List<PropertyType> { new PropertyType(contentPickerDataTypeDefinition,"picker") });
 
             var ncMediaPickerContentType = new Mock<IContentType>();
 
-            ncMediaPickerContentType.SetupGet(x => x.PropertyTypes)
+            ncMediaPickerContentType.SetupGet(x => x.CompositionPropertyTypes)
                 .Returns(new List<PropertyType> { new PropertyType(mediaPickerDataTypeDefinition,"picker") });
 
             contentTypeServiceMock.Setup(x => x.GetContentType("NCContentPicker")).Returns(ncContentPickerContentType.Object);

--- a/Source/Our.Umbraco.Nexu.Parsers.Tests/PropertyParsers/Community/StackedContentParserTests.cs
+++ b/Source/Our.Umbraco.Nexu.Parsers.Tests/PropertyParsers/Community/StackedContentParserTests.cs
@@ -134,7 +134,7 @@
             // setup content types and content service calls
             var contentType1 = new Mock<IContentType>();
 
-            contentType1.SetupGet(x => x.PropertyTypes)
+            contentType1.SetupGet(x => x.CompositionPropertyTypes)
                 .Returns(new List<PropertyType>
                              {
                                  new PropertyType(rteDataTypeDefinition, text),
@@ -143,7 +143,7 @@
 
             var contentType2 = new Mock<IContentType>();
 
-            contentType2.SetupGet(x => x.PropertyTypes)
+            contentType2.SetupGet(x => x.CompositionPropertyTypes)
                 .Returns(new List<PropertyType>
                              {
                                  new PropertyType(contentPickerDataTypeDefinition, link),

--- a/Source/Our.Umbraco.Nexu.Parsers.Tests/PropertyParsers/Core/NestedContentParserTests.cs
+++ b/Source/Our.Umbraco.Nexu.Parsers.Tests/PropertyParsers/Core/NestedContentParserTests.cs
@@ -105,12 +105,12 @@
 
             var ncContentPickerContentType = new Mock<IContentType>();           
 
-            ncContentPickerContentType.SetupGet(x => x.PropertyTypes)
+            ncContentPickerContentType.SetupGet(x => x.CompositionPropertyTypes)
                 .Returns(new List<PropertyType> { new PropertyType(contentPickerDataTypeDefinition,"picker") });
 
             var ncMediaPickerContentType = new Mock<IContentType>();
 
-            ncMediaPickerContentType.SetupGet(x => x.PropertyTypes)
+            ncMediaPickerContentType.SetupGet(x => x.CompositionPropertyTypes)
                 .Returns(new List<PropertyType> { new PropertyType(mediaPickerDataTypeDefinition,"picker") });
 
             contentTypeServiceMock.Setup(x => x.GetContentType("NCContentPicker")).Returns(ncContentPickerContentType.Object);

--- a/Source/Our.Umbraco.Nexu.Parsers/GridEditorParsers/Community/DocTypeGridEditorParser.cs
+++ b/Source/Our.Umbraco.Nexu.Parsers/GridEditorParsers/Community/DocTypeGridEditorParser.cs
@@ -108,7 +108,7 @@
                             {
                                 var propAlias = item.Name;
 
-                                var property = contentType.PropertyTypes.FirstOrDefault(x => x.Alias == propAlias);
+                                var property = contentType.CompositionPropertyTypes.FirstOrDefault(x => x.Alias == propAlias);
 
                                 if (property != null)
                                 {

--- a/Source/Our.Umbraco.Nexu.Parsers/Properties/AssemblyInfo.cs
+++ b/Source/Our.Umbraco.Nexu.Parsers/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.7.3.0")]
-[assembly: AssemblyFileVersion("1.7.3.0")]
+[assembly: AssemblyVersion("1.7.4.0")]
+[assembly: AssemblyFileVersion("1.7.4.0")]

--- a/Source/Our.Umbraco.Nexu.Parsers/PropertyParsers/Community/NestedContentParser.cs
+++ b/Source/Our.Umbraco.Nexu.Parsers/PropertyParsers/Community/NestedContentParser.cs
@@ -112,7 +112,7 @@
                         var contentType = contentTypes[doctypeAlias];
 
                         // get all datatypes for this content type
-                        foreach (var propertyType in contentType.PropertyTypes)
+                        foreach (var propertyType in contentType.CompositionPropertyTypes)
                         {
                             if (!dataTypes.ContainsKey(propertyType.DataTypeDefinitionId))
                             {

--- a/Source/Our.Umbraco.Nexu.Parsers/PropertyParsers/Community/StackedContentParser.cs
+++ b/Source/Our.Umbraco.Nexu.Parsers/PropertyParsers/Community/StackedContentParser.cs
@@ -111,7 +111,7 @@
                         var doctype = contentTypes[docTypeGuid];
 
                         // get all datatypes for this content type
-                        foreach (var propertyType in doctype.PropertyTypes)
+                        foreach (var propertyType in doctype.CompositionPropertyTypes)
                         {
                             if (!dataTypes.ContainsKey(propertyType.DataTypeDefinitionId))
                             {

--- a/Source/Our.Umbraco.Nexu.Parsers/PropertyParsers/Core/NestedContentParser.cs
+++ b/Source/Our.Umbraco.Nexu.Parsers/PropertyParsers/Core/NestedContentParser.cs
@@ -112,7 +112,7 @@
                         var contentType = contentTypes[doctypeAlias];
 
                         // get all datatypes for this content type
-                        foreach (var propertyType in contentType.PropertyTypes)
+                        foreach (var propertyType in contentType.CompositionPropertyTypes)
                         {
                             if (!dataTypes.ContainsKey(propertyType.DataTypeDefinitionId))
                             {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
 os: Visual Studio 2015
 
 # Version format
-version: 1.7.3.{build}
+version: 1.7.4.{build}
 
 cache:
   - Source\packages -> **\packages.config   # preserve "packages" directory in the root of build folder but will reset it if packages.config is modified


### PR DESCRIPTION
This resolves issue #61 by using the property CompositionPropertyTypes on a content type to ensure we get declared properties as well as those included via composition.  This ensures that any time a content editor uses a picker which is part of a composition to include related content on a node, then a relationship is created between those two nodes.  I have updated all places that the ContentType.PropertyTypes property was referenced, and not just the one place references in issue #61.  I have confirmed that this change resolves the problem noted in that issue.