### PR TITLE
make content app appear last, reason being when u have no content and…

### DIFF
--- a/src/Our.Umbraco.Nexu.Web/Composing/Components/RelatedLinksContentAppFactory.cs
+++ b/src/Our.Umbraco.Nexu.Web/Composing/Components/RelatedLinksContentAppFactory.cs
@@ -38,6 +38,7 @@
             return new ContentApp
                        {
                            Alias = "nexuRelatedLinksApp",
+                           Weight = 99,
                            Icon = "icon-link",
                            Name = "Related links",
                            View = "/App_Plugins/Nexu/views/related-links-app.html",


### PR DESCRIPTION
… related links then when u try to create new content u cannot edit name unless u swap to info tab