### PR TITLE
Added support for the social media property in SEO Checker

### DIFF
--- a/src/Our.Umbraco.Nexu.Parsers.Tests/Community/SEOCheckerParserTests.cs
+++ b/src/Our.Umbraco.Nexu.Parsers.Tests/Community/SEOCheckerParserTests.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Our.Umbraco.Nexu.Parsers.Tests.Community
+{
+    using System.Linq;
+
+    using global::Umbraco.Core;
+
+    using NUnit.Framework;
+
+    using Our.Umbraco.Nexu.Common.Constants;
+    using Our.Umbraco.Nexu.Parsers.Core;
+
+    [TestFixture]
+    public class SEOCheckerParserTests
+    {
+        [Test]
+        public void When_EditorAlias_Is_Not_Correct_IsParserFor_Should_Return_False()
+        {
+            // arrange       
+            var parser = new SEOCheckerParser();
+
+            // act
+            var result = parser.IsParserFor(Constants.PropertyEditors.Aliases.Boolean);
+
+            // assert
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void When_EditorAlias_Is_Correct_IsParserFor_Should_Return_True()
+        {
+            // arrange
+            var parser = new SEOCheckerParser();
+
+            // act
+            var result = parser.IsParserFor("SEOChecker.SEOCheckerSocialPropertyEditor");
+
+            // assert
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void When_Value_Is_Not_Set_GetRelatedEntities_Return_Empty_List()
+        {
+            // arrange
+            var parser = new SEOCheckerParser();
+
+            // act
+            var result = parser.GetRelatedEntities(null).ToList();
+
+            // assert
+            Assert.IsNotNull(result);
+            Assert.That(result.Count == 0);
+        }
+
+        [Test]
+        public void When_Value_Is_Set_GetRelatedEntities_Return_List_With_Related_Entities()
+        {
+            // arrange
+            var seoCheckerXML =
+                "<SEOCheckerSocial><socialImage>umb://media/6f2d6d1d13a8438789b3cf0cced47344</socialImage><ogTitle></ogTitle><ogDescription></ogDescription><twitterTitle></twitterTitle> <twitterDescription></twitterDescription></SEOCheckerSocial>";
+
+            var parser = new SEOCheckerParser();
+
+            // act
+            var result = parser.GetRelatedEntities(seoCheckerXML).ToList();
+
+            // assert
+            Assert.IsNotNull(result);
+            Assert.That(result.Count == 1);
+            Assert.That(result.Count(x => x.RelationType == RelationTypes.DocumentToMedia) == 1);
+
+            Assert.That(result.Exists(x => x.RelatedEntityUdi.ToString() == "umb://media/6f2d6d1d13a8438789b3cf0cced47344"));
+        }
+    }
+}

--- a/src/Our.Umbraco.Nexu.Parsers.Tests/Our.Umbraco.Nexu.Parsers.Tests.csproj
+++ b/src/Our.Umbraco.Nexu.Parsers.Tests/Our.Umbraco.Nexu.Parsers.Tests.csproj
@@ -191,6 +191,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Community\SEOCheckerParserTests.cs" />
     <Compile Include="Core\ContentPickerParserTests.cs" />
     <Compile Include="Core\GridParserTests.cs" />
     <Compile Include="Core\MediaPickerParserTests.cs" />

--- a/src/Our.Umbraco.Nexu.Parsers/Community/SEOCheckerParser.cs
+++ b/src/Our.Umbraco.Nexu.Parsers/Community/SEOCheckerParser.cs
@@ -1,0 +1,64 @@
+﻿using Our.Umbraco.Nexu.Parsers.Helpers;
+
+namespace Our.Umbraco.Nexu.Parsers.Core
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Xml.Linq;
+    using global::Umbraco.Core;
+
+    using Our.Umbraco.Nexu.Common.Interfaces.Models;
+    using Our.Umbraco.Nexu.Common.Models;
+
+    /// <summary>
+    /// Represents content picker parser.
+    /// </summary>
+    public class SEOCheckerParser : IPropertyValueParser
+    {
+        /// <inheritdoc />
+        public bool IsParserFor(string propertyEditorAlias)
+        {
+            return propertyEditorAlias.Equals("SEOChecker.SEOCheckerSocialPropertyEditor");
+        }
+
+        /// <inheritdoc />
+        public IEnumerable<IRelatedEntity> GetRelatedEntities(string value)
+        {
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                var entities = new List<IRelatedEntity>();
+                var model = XDocument.Parse(value).Root;
+                if (model != null)
+                {
+                    try
+                    {
+                        var socialImage = model.Descendants("socialImage").FirstOrDefault();
+                        if (socialImage == null)
+                        {
+                            return Enumerable.Empty<IRelatedEntity>();
+                        }
+
+                        if (string.IsNullOrEmpty(socialImage.Value))
+                        {
+                            return Enumerable.Empty<IRelatedEntity>();
+                        }
+
+                        foreach (var documentUdi in ParserUtilities.GetMediaUdiFromText(socialImage.Value).ToList())
+                        {
+                            entities.Add(new RelatedMediaEntity
+                            {
+                                RelatedEntityUdi = documentUdi,
+                            });
+                        }
+
+                        return entities;
+                    }
+                    catch { }
+                }
+            }
+
+            return Enumerable.Empty<IRelatedEntity>();
+        }
+    }
+}

--- a/src/Our.Umbraco.Nexu.Parsers/Our.Umbraco.Nexu.Parsers.csproj
+++ b/src/Our.Umbraco.Nexu.Parsers/Our.Umbraco.Nexu.Parsers.csproj
@@ -146,6 +146,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BaseTextParser.cs" />
+    <Compile Include="Community\SEOCheckerParser.cs" />
     <Compile Include="Core\ContentPickerParser.cs" />
     <Compile Include="Core\GridParser.cs" />
     <Compile Include="Core\MediaPickerParser.cs" />


### PR DESCRIPTION
This change is to allow Nexu to Parse the Social Image Media property of SEO Checker (https://soetemansoftware.nl/seo-checker). It has been tested against:

Umbraco 8.6.0
SEOChecker 2.9.0

I've followed the same patterns as the v7 branch
